### PR TITLE
Add Mini-Tools.uk Image Color Picker

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,6 +204,7 @@ Resource for everything related to UI / UX. Contributions are welcome, just do a
 
   * [SMW: Color Psychology](http://socialmediaweek.org/blog/2014/08/use-color-psychology-web-design-projects/)
 
+  * [Mini-Tools.uk Image Color Picker](https://mini-tools.uk/color-picker) - Pick colors from images or screenshots, crop small areas, and copy HEX, RGB or HSL values.
   * [GMD: Color](https://www.google.com/design/spec/style/color.html)
 
   * [DFF: Color theory](http://www.designforfounders.com/color-theory/)


### PR DESCRIPTION
Hi, I'd like to add Mini-Tools.uk Image Color Picker to the Style > Colors section.

Self-recommendation: I built and use this small color picker myself. It is for a workflow I run into often: grabbing an exact color from a screenshot, mockup, product image, or UI reference without opening a full design app.

The workflow is intentionally simple: open an image, crop a small area if needed, pick a color, and copy the HEX/RGB/HSL value.